### PR TITLE
[BUGFIX] Do not show empty results

### DIFF
--- a/Classes/ExternalLinks/ExternalLink.php
+++ b/Classes/ExternalLinks/ExternalLink.php
@@ -88,6 +88,9 @@ class ExternalLink
 
     public function toCliTableRow(): array
     {
+        if ($this->conversionMemory === []) {
+            return [];
+        }
         return [
             $this->pid,
             $this->table,

--- a/Classes/ExternalLinks/Output/TableOutput.php
+++ b/Classes/ExternalLinks/Output/TableOutput.php
@@ -60,7 +60,11 @@ class TableOutput
         $table = new Table($this->output);
         $table->setHeaders(['PID', 'Table', 'UID', 'Field', 'Found external Link', 'Would be converted to']);
         foreach ($this->collection as $externalLink) {
-            $table->addRow($externalLink->toCliTableRow());
+            $result = $externalLink->toCliTableRow();
+            if ($result === []) {
+                continue;
+            }
+            $table->addRow($result);
         }
         $table->render();
 


### PR DESCRIPTION
If external links cannot be converted, to not show results with empty
result columns.

Resolves: #4