### PR TITLE
[BUGFIX] Handle links to translated pages

### DIFF
--- a/Classes/ExternalLinks/Converter/PageLinkConverter.php
+++ b/Classes/ExternalLinks/Converter/PageLinkConverter.php
@@ -50,7 +50,11 @@ class PageLinkConverter extends Converter implements SingletonInterface
         foreach ($link->getMatchedLinks() as $matchedLink) {
             foreach ($this->getUrlCandidates($link) as $url) {
                 if ($matchedLink === $url['uri']) {
-                    $link->convert($matchedLink, 't3://page?uid=' . $url['target']);
+                    $targetUri = 't3://page?uid=' . $url['target'];
+                    if ($link->getLanguage()->getLanguageId() !== 0) {
+                        $targetUri .= '&_language=' . $link->getLanguage()->getLanguageId();
+                    }
+                    $link->convert($matchedLink, $targetUri);
                     continue 2;
                 }
             }


### PR DESCRIPTION
Add language parameter _language for links to translated pages.
This is the same procedure as now used in core EXT:redirect
to generate t3 URIs to translated pages.

Resolves: #9