### PR TITLE
[BUGFIX] Fix PHP warning about undefined array key

### DIFF
--- a/Classes/ExternalLinks/Converter/PageLinkConverter.php
+++ b/Classes/ExternalLinks/Converter/PageLinkConverter.php
@@ -68,7 +68,7 @@ class PageLinkConverter extends Converter implements SingletonInterface
         if (isset($this->urlCache[$rootPageId][$languageId])) {
             return $this->urlCache[$rootPageId][$languageId];
         }
-        if (!is_array($this->urlCache[$rootPageId])) {
+        if (!isset($this->urlCache[$rootPageId]) || !is_array($this->urlCache[$rootPageId])) {
             $this->urlCache[$rootPageId] = [];
         }
 


### PR DESCRIPTION
This patch fixes an PHP 8.1 warning about an undefined array key.